### PR TITLE
Separate birthdate, birthday and age. Add some expressions and answers

### DIFF
--- a/packages/leon/README.md
+++ b/packages/leon/README.md
@@ -111,7 +111,7 @@ Leon introduces himself.
 
 ### How old
 
-Leon tells when it has been created.
+Leon tells it's age.
 
 #### Usage
 
@@ -119,5 +119,19 @@ Leon tells when it has been created.
 (en-US) "How old are you?"
 
 (fr-FR) "Quel âge as-tu?"
+...
+```
+
+
+### Birthdate
+
+Leon tells it's birthdate or it's next birthday.
+
+#### Usage
+
+```
+(en-US) "When were you born?"
+
+(fr-FR) "Quand es-tu né?"
 ...
 ```

--- a/packages/leon/birthdate.py
+++ b/packages/leon/birthdate.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python
+# -*- coding:utf-8 -*-
+
+import utils
+
+def date(string, entities):
+	"""Leon says when it was created"""
+
+	return utils.output('end', 'date', utils.translate('date'))
+
+def birthday(string, entities):
+	"""Leon says when is it's birthday"""
+
+	return utils.output('end', 'birthday', utils.translate('birthday'))

--- a/packages/leon/config/config.sample.json
+++ b/packages/leon/config/config.sample.json
@@ -25,5 +25,8 @@
   },
   "howold": {
     "options": {}
+  },
+  "birthdate": {
+    "options": {}
   }
 }

--- a/packages/leon/data/answers/en.json
+++ b/packages/leon/data/answers/en.json
@@ -110,7 +110,21 @@
   },
   "howold": {
   	"age": [
-  		"I have been created on February 10, 2019. Therefore, I am %years% years and %days% days old."
+		"I have been created on February 10, 2019. Therefore, I am %years% years and %days% days old.",
+		"I am still very young, I am only %years% years and %days% days old.",
+		"I'm only %years% years and %days% days old, but I can already talk !",
+		"I am only %years% years and %days% days old. How does it feel to be older ?",
+		"I am surely much younger than you, I am only %years% years and %days% days old."
   	]
+  },
+  "birthdate": {
+    "date": [
+		"I have been created on february 10, 2019.",
+		"My first version is dated February 10th of 2019."
+	],
+	"birthday": [
+		"Next February 10th will be my birthday.",
+		"My birthday is February 10th."
+	]
   }
 }

--- a/packages/leon/data/answers/fr.json
+++ b/packages/leon/data/answers/fr.json
@@ -115,8 +115,21 @@
     ]
   },
   "howold": {
-  	"age": [
-  		"J'ai été créé le 10 Février 2019. J'ai donc %years% ans et %days% jours!"
-  	]
+	"age": [
+		"Je suis encore très jeune, je n'ai que %years% ans et %days% jours.",
+		"J'ai seulement %years% ans et %days% jours, mais je peux déjà parler !",
+		"Je n'ai que %years% ans et %days% jours. Qu'est-ce que ça fait d'être plus âgé ?",
+		"Je suis sûrement bien plus jeune que vous, j'ai seulement %years% ans et %days% jours."
+	]
+  },
+  "birthdate": {
+	"date": [
+		"J'ai été créé le 10 février 2019.",
+		"Ma première version date du 10 février 2019."
+	],
+	"birthday": [
+		"Le 10 février prochain sera mon anniversaire.",
+		"Mon anniversaire est le 10 février."
+	]
   }
 }

--- a/packages/leon/data/expressions/en.json
+++ b/packages/leon/data/expressions/en.json
@@ -95,8 +95,20 @@
       "expressions": [
         "How old are you?",
         "Are you old?",
-        "Are you young?",
+        "Are you young?"
+      ]
+    }
+  },
+  "birthdate": {
+    "date": {
+      "expressions": [
+        "When were you born?",
         "When have you been created?"
+      ]
+    },
+    "birthday": {
+      "expressions": [
+        "When is your birthday?"
       ]
     }
   }

--- a/packages/leon/data/expressions/fr.json
+++ b/packages/leon/data/expressions/fr.json
@@ -95,8 +95,20 @@
       "expressions": [
         "Quel âge as-tu ?",
         "Es-tu vieux ?",
-        "Es-tu jeune ?",
-        "Quand as-tu été créé ?"
+        "Es-tu jeune ?"
+      ]
+    }
+  },
+  "birthdate": {
+    "date": {
+      "expressions": [
+        "Quand es-tu né?",
+        "Quand as-tu été créé?"
+      ]
+    },
+    "birthday": {
+      "expressions": [
+        "Quelle est ta date de naissance?"
       ]
     }
   }

--- a/packages/leon/howold.py
+++ b/packages/leon/howold.py
@@ -5,7 +5,7 @@ import utils
 import datetime
 
 def run(string, entities):
-	"""Leon says when it was created"""
+	"""Leon says it's age"""
 
 	age = datetime.date.today() - datetime.date(2019, 2, 10)
 

--- a/packages/leon/test/birthdate.spec.js
+++ b/packages/leon/test/birthdate.spec.js
@@ -1,0 +1,23 @@
+'use strict'
+
+describe('leon:birthdate', async () => {
+  test('says when it was created', async () => {
+    global.nlu.brain.execute = jest.fn()
+    await global.nlu.process('When were you born?')
+
+    const [obj] = global.nlu.brain.execute.mock.calls
+    await global.brain.execute(obj[0])
+
+    expect(global.brain.finalOutput.codes).toIncludeSameMembers(['date'])
+  })
+
+  test('says when is is\'s next birthday', async () => {
+    global.nlu.brain.execute = jest.fn()
+    await global.nlu.process('When is your birthday?')
+
+    const [obj] = global.nlu.brain.execute.mock.calls
+    await global.brain.execute(obj[0])
+
+    expect(global.brain.finalOutput.codes).toIncludeSameMembers(['birthday'])
+  })
+})


### PR DESCRIPTION
<!--

Thanks a lot for your interest in contributing to Leon! :heart:

Please first discuss the change you wish to make via issue,
email, or any other method with the owners of this repository before making a change.
It might avoid a waste of your time.

Before submitting your contribution, please take a moment to review this document:
https://github.com/leon-ai/leon/blob/develop/.github/CONTRIBUTING.md

Please place an x (no spaces - [x]) in all [ ] that apply.

-->

### What type of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Not Sure?

### Does this PR introduce breaking changes?
- [ ] Yes
- [x] No

### List any relevant issue numbers:

#142 

### Description:

I have separate birthdate, birthday and age so that Leon gives us his creation date or his age depending on what we ask him.
I also have added some expressions and answers for those points.
This is, I think, what was missing to make your PR being merged into Leon.

Cheers